### PR TITLE
Improve video dimension handling with dynamic frame detection

### DIFF
--- a/pyscreenrec/__init__.py
+++ b/pyscreenrec/__init__.py
@@ -131,6 +131,7 @@ class ScreenRecorder:
         need to written to the video, and also releases the video when `stop_recording`
         is called.
         """
+        video = None
         try:
             img = self.queue.get()
             if img is None:
@@ -155,9 +156,12 @@ class ScreenRecorder:
                 video.write(cv2.cvtColor(np.array(img), cv2.COLOR_BGRA2BGR))
 
         except Exception as e:
-            logger.error(f"Error in video writing: {e}")
+            print(f"Unexpected error in video writing: {e}")
+            raise
+
         finally:
-            video.release()
+            if video is not None:
+                video.release()
 
     def stop_recording(self) -> None:
         """

--- a/pyscreenrec/__init__.py
+++ b/pyscreenrec/__init__.py
@@ -131,19 +131,33 @@ class ScreenRecorder:
         need to written to the video, and also releases the video when `stop_recording`
         is called.
         """
-        width, height = self.mon["width"], self.mon["height"]
-
-        video = cv2.VideoWriter(
-            self.video_name, cv2.VideoWriter_fourcc(*"mp4v"), self.fps, (width, height)
-        )
-
-        while True:
+        try:
             img = self.queue.get()
             if img is None:
-                break
-            video.write(cv2.cvtColor(np.array(img), cv2.COLOR_BGRA2BGR))
+                return
 
-        video.release()
+            frame = cv2.cvtColor(np.array(img), cv2.COLOR_BGRA2BGR)
+            height, width = frame.shape[:2]
+
+            if width <= 0 or height <= 0:
+                raise ValueError("Invalid width or height.")
+
+            video = cv2.VideoWriter(
+                self.video_name, cv2.VideoWriter_fourcc(*"mp4v"), self.fps, (width, height)
+            )
+
+            video.write(frame)
+
+            while True:
+                img = self.queue.get()
+                if img is None:
+                    break
+                video.write(cv2.cvtColor(np.array(img), cv2.COLOR_BGRA2BGR))
+
+        except Exception as e:
+            logger.error(f"Error in video writing: {e}")
+        finally:
+            video.release()
 
     def stop_recording(self) -> None:
         """


### PR DESCRIPTION
## Issue
While recording screen captures, I encountered an unusable video of 257 bytes. After investigating the issue, I found that the expected frame size was (2560, 2240), but the actual captured frame size was (5120, 4480). This issue typically occurs on macOS Retina displays. Therefore, I submitted this PR to make the written frame size adapt to the actual dimensions automatically.


## Changes
This PR improves the video recording functionality by replacing static monitor dimensions with dynamic frame size detection.


### Key Changes
- Modified `_write_img_to_stream` to use actual frame dimensions
- Removed dependency on predefined monitor settings
- Added frame validation before VideoWriter initialization
- Improved code reliability and flexibility

### Benefits
1. Better support for different screen resolutions
2. More reliable video initialization
3. Reduced dependency on external configurations
4. More flexible handling of various recording scenarios

### Testing
- Tested with different screen resolutions
- Verified video output dimensions match input frames
- Checked handling of invalid frames

